### PR TITLE
Remove deprecated appcast

### DIFF
--- a/Casks/micronaut.rb
+++ b/Casks/micronaut.rb
@@ -4,7 +4,7 @@ cask 'micronaut' do
 
   # github.com/micronaut-projects/micronaut-starter was verified as official when first introduced to the cask
   url "https://github.com/micronaut-projects/micronaut-starter/releases/download/v#{version}/mn-darwin-amd64-v#{version}.zip"
-  appcast 'https://github.com/micronaut-projects/micronaut-starter/releases.atom'
+  livecheck 'https://github.com/micronaut-projects/micronaut-starter/releases.atom'
   name 'Micronaut'
   homepage 'https://micronaut.io'
 


### PR DESCRIPTION
> Warning: Calling the `appcast` stanza is deprecated! Use the `livecheck` stanza instead.